### PR TITLE
Import-Module inside vsts-prerequisites.ps1

### DIFF
--- a/templates/PSFProject/build/vsts-prerequisites.ps1
+++ b/templates/PSFProject/build/vsts-prerequisites.ps1
@@ -1,6 +1,7 @@
-﻿Write-Host "Installing Pester" -ForegroundColor Cyan
-Install-Module Pester -Force -SkipPublisherCheck
-Write-Host "Installing PSFramework" -ForegroundColor Cyan
-Install-Module PSFramework -Force -SkipPublisherCheck
-Write-Host "Installing PSScriptAnalyzer" -ForegroundColor Cyan
-Install-Module PSScriptAnalyzer -Force -SkipPublisherCheck
+﻿$modules = @("Pester", "PSFramework", "PSScriptAnalyzer")
+
+foreach ($module in $modules) {
+    Write-Host "Installing $module" -ForegroundColor Cyan
+    Install-Module $module -Force -SkipPublisherCheck
+    Import-Module $module -Force -PassThru
+}


### PR DESCRIPTION
I have seen several failed builds over the last few day with errors like it found the command, but could not load the module.

Here we load the module explicitly and get the version into the logs