### PR TITLE
Proposed fix to #100

### DIFF
--- a/templates/PSFTests/general/Manifest.Tests.ps1
+++ b/templates/PSFTests/general/Manifest.Tests.ps1
@@ -40,10 +40,17 @@
 		
 		foreach ($assembly in $manifest.RequiredAssemblies)
 		{
-			It "The file $assembly should exist" {
-				Test-Path "$moduleRoot\$assembly" | Should -Be $true
-			}
-		}
+            if ($assembly -contains ".dll") {
+                It "The file $assembly should exist" {
+                    Test-Path "$moduleRoot\$assembly" | Should -Be $true
+                }
+            }
+            else {
+                It "The file $assembly should load from the GAC" {
+                    { Add-Type -AssemblyName $assembly } | Should -Not -Throw
+                }
+            }
+        }
 		
 		foreach ($tag in $manifest.PrivateData.PSData.Tags)
 		{


### PR DESCRIPTION
This should make sure to use the "old" logic for any files reference by name, based on if they have .dll in their name. Otherwise it will simply try and load using the Add-Type and make sure it doesn't throw an error.