### PR TITLE
Fix for command types on pwsh in Help.Tests.ps1

### DIFF
--- a/templates/PSFTests/general/Help.Tests.ps1
+++ b/templates/PSFTests/general/Help.Tests.ps1
@@ -48,7 +48,9 @@ if ($SkipTest) { return }
 . $ExceptionsFile
 
 $includedNames = (Get-ChildItem $CommandPath -Recurse -File | Where-Object Name -like "*.ps1").BaseName
-$commands = Get-Command -Module (Get-Module $ModuleName) -CommandType Cmdlet, Function, Workflow | Where-Object Name -in $includedNames
+$commandTypes = @('Cmdlet', 'Function')
+if ($PSVersionTable.PSEdition -eq 'Desktop' ) { $commandTypes += 'Workflow' }
+$commands = Get-Command -Module (Get-Module $ModuleName) -CommandType $commandTypes | Where-Object Name -In $includedNames
 
 ## When testing help, remember that help is cached at the beginning of each session.
 ## To test, restart session.


### PR DESCRIPTION
The Help.Tests.ps1 in the PSFTests attempts to test all commands of type Cmdlet, Function, and Workflow. The -CommandType parameter of Get-Command expects a collection of [System.Management.Automation.CommandTypes] . Workflow was removed from this enum in pwsh causing the test to error.

This pull request sets cmdlet and function as the default and adds workflow if the detected PSVersiontable.PSEdition is Desktop.