### PR TITLE
Fixed #112

### DIFF
--- a/PSModuleDevelopment/internal/configurations/template.ps1
+++ b/PSModuleDevelopment/internal/configurations/template.ps1
@@ -9,8 +9,8 @@ Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.ParameterDefault.Com
 Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.BinaryExtensions' -Value @('.dll', '.exe', '.pdf', '.doc', '.docx', '.xls', '.xlsx') -Initialize -Description "When creating a template, files with these extensions will be included as raw bytes and not interpreted for parameter insertion."
 
 # Define the default store. To add more stores, just add a similar setting with a different last name segment
-Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.Store.Default' -Value "$path_FileUserShared\WindowsPowerShell\PSModuleDevelopment\Templates" -Initialize -Validation "string" -Description "Path to the default directory where PSModuleDevelopment will store its templates. You can add additional stores by creating the same setting again, only changing the last name segment to a new name and configuring a separate path."
-Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.Store.PSModuleDevelopment' -Value "$script:ModuleRoot\internal\templates" -Initialize -Validation "string" -Description "Path to the templates shipped in PSModuleDevelopment"
+Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.Store.Default' -Value "$path_FileUserShared/WindowsPowerShell/PSModuleDevelopment/Templates" -Initialize -Validation "string" -Description "Path to the default directory where PSModuleDevelopment will store its templates. You can add additional stores by creating the same setting again, only changing the last name segment to a new name and configuring a separate path."
+Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.Store.PSModuleDevelopment' -Value "$script:ModuleRoot/internal/templates" -Initialize -Validation "string" -Description "Path to the templates shipped in PSModuleDevelopment"
 
 # Define the default path to create from templates in
 Set-PSFConfig -Module 'PSModuleDevelopment' -Name 'Template.OutPath' -Value '.' -Initialize -Validation 'string' -Description "The path where new files & projects should be created from templates by default."

--- a/PSModuleDevelopment/internal/scripts/variables.ps1
+++ b/PSModuleDevelopment/internal/scripts/variables.ps1
@@ -4,7 +4,7 @@
 	$fileUserShared = @($Env:XDG_CONFIG_DIRS -split ([IO.Path]::PathSeparator))[0]
 	if (-not $fileUserShared) { $fileUserShared = Join-Path $HOME .local/share/ }
 	
-	$path_FileUserShared = Join-Path (Join-Path $fileUserShared $psVersionName) "PSFramework/"
+	$path_FileUserShared = Join-Path (Join-Path $fileUserShared $psVersionName) "PSFramework"
 }
 else
 {


### PR DESCRIPTION
Using forward slashes helps. On Linux, the folders created had the name `\WindowsPowerShell\PSFramework\Templates`, which of course makes things a bit complicated :)

I have not gotten to testing this on Windows, but since Windows does not care about slashes, I would hope that this just works.

I tested my changes on Fedora 32, but other distros should not make a difference.