### PR TITLE
2.2.11.139

### DIFF
--- a/PSModuleDevelopment/PSModuleDevelopment.psd1
+++ b/PSModuleDevelopment/PSModuleDevelopment.psd1
@@ -5,7 +5,7 @@
 
 	# Version number of this module.
 
-	ModuleVersion = '2.2.11.138'
+	ModuleVersion = '2.2.11.139'
 
   # ID used to uniquely identify this module
 	GUID = '37dd5fce-e7b5-4d57-ac37-832055ce49d6'

--- a/PSModuleDevelopment/PSModuleDevelopment.psd1
+++ b/PSModuleDevelopment/PSModuleDevelopment.psd1
@@ -4,9 +4,10 @@
 	RootModule = 'PSModuleDevelopment.psm1'
 
 	# Version number of this module.
+
 	ModuleVersion = '2.2.11.138'
 
-	# ID used to uniquely identify this module
+  # ID used to uniquely identify this module
 	GUID = '37dd5fce-e7b5-4d57-ac37-832055ce49d6'
 
 	# Author of this module
@@ -157,10 +158,3 @@
 
 	} # End of PrivateData hashtable
 }
-
-
-
-
-
-
-

--- a/PSModuleDevelopment/changelog.md
+++ b/PSModuleDevelopment/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 2.2.11.139 (2022-04-29)
+
++ Fix: Invoke-PSMDTemplate - fails to generate templates on PS 5.1, due to splatting vs. explicitly bound parameter (#172)
+
 ## 2.2.11.138 (2022-04-19)
 
 + New: Template MiniModule - a scaffold for a minimal dependencies module

--- a/PSModuleDevelopment/functions/templating/Invoke-PSMDTemplate.ps1
+++ b/PSModuleDevelopment/functions/templating/Invoke-PSMDTemplate.ps1
@@ -412,7 +412,7 @@
 			)
 			$msgParam = @{ Level = 'Verbose'; FunctionName = 'Invoke-PSMDTemplate' }
 			foreach ($item in $TemplateResult | Sort-Object { $_.FullPath.Length }) {
-				Write-PSFMessage @msgParam -Message "Creating file: $($item.FullPath)" -FunctionName Invoke-PSMDTemplate -ModuleName PSModuleDevelopment -Tag 'create', 'template'
+				Write-PSFMessage @msgParam -Message "Creating file: $($item.FullPath)" -Tag 'create', 'template'
 				if (-not (Test-Path $item.Path)) {
 					Write-PSFMessage -Level Verbose -Message "Creating Folder $($item.Path)"
 					$null = New-Item -Path $item.Path -ItemType Directory


### PR DESCRIPTION
+ Fix: Invoke-PSMDTemplate - fails to generate templates on PS 5.1, due to splatting vs. explicitly bound parameter (#172)