### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/templates/PSFProject/azure-pipelines.yml
+++ b/templates/PSFProject/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  name: Hosted VS2017
+  vmImage: "windows-latest"
 steps:
 - task: PowerShell@2
   displayName: Prerequisites


### PR DESCRIPTION
As the windows 2016 hosted runners is deprecated, the best practice is to replace it with windows-latest.
Any new PSMDProject shouldn't use the 2016 host anymore.

See GitHub Issue:
https://github.com/actions/virtual-environments/issues/5403

Windows 2016 hosted runners were scheduled for full removal on April 1, 2022. However, we are still seeing significant usage from customers and we want to give them more time to migrate to the new runners. In order to give customers another chance to move to either windows-2019 or windows-2022 we will delay the removal of windows-2016 until June 30, 2022.